### PR TITLE
feat(order): 주문 목록/상세 페이지 UI 구현

### DIFF
--- a/src/app/orders/[id]/page.tsx
+++ b/src/app/orders/[id]/page.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { use } from 'react';
+import { useRouter } from 'next/navigation';
+import { AppShell } from '@/components/layout/AppShell';
+import { Footer } from '@/components/layout/Footer';
+import { Card, CardContent } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { InlineError } from '@/components/common/InlineError';
+import { useOrder } from '@/features/order/hooks/useOrders';
+import type { OrderStatus, OrderItemType, OrderItemStatus } from '@/types/order';
+
+const PAYMENT_METHOD_LABELS: Record<string, string> = {
+    DEPOSIT: '지갑',
+    CARD: '카드',
+    KAKAO_PAY: '카카오페이',
+    NAVER_PAY: '네이버페이',
+    TOSS_PAY: '토스페이',
+    ACCOUNT_TRANSFER: '계좌이체',
+    VIRTUAL_ACCOUNT: '가상계좌',
+    BANK_TRANSFER: '은행이체',
+    POINT: '포인트',
+};
+
+const ORDER_STATUS_LABEL: Record<OrderStatus, string> = {
+    CREATED: '주문생성',
+    PAID: '결제완료',
+    PARTIAL_CONFIRMED: '부분확정',
+    CONFIRMED: '주문확정',
+    PARTIAL_CANCELING: '부분취소중',
+    CANCELING: '취소처리중',
+    PARTIAL_CANCELED: '부분취소',
+    CANCELED: '주문취소',
+};
+
+const ITEM_TYPE_LABEL: Record<OrderItemType, string> = {
+    NORMAL_ORDER: '일반 주문',
+    FUNDING_GIFT: '펀딩 선물',
+    NORMAL_GIFT: '일반 선물',
+};
+
+const ITEM_STATUS_LABEL: Record<OrderItemStatus, string> = {
+    CREATED: '생성',
+    PAID: '결제완료',
+    CANCELING: '취소중',
+    CANCELED: '취소됨',
+    CONFIRMED: '확정',
+};
+
+function formatDateTime(dateStr: string) {
+    return new Date(dateStr).toLocaleString('ko-KR', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+}
+
+export default function OrderDetailPage({ params }: { params: Promise<{ id: string }> }) {
+    const { id } = use(params);
+    const router = useRouter();
+    const { data, isLoading, isError, refetch } = useOrder(id);
+
+    if (isLoading) {
+        return (
+            <AppShell headerTitle="주문 상세" headerVariant="detail" hasBack showBottomNav={false}>
+                <div className="p-4 space-y-4">
+                    <Skeleton className="h-40 w-full rounded-lg" />
+                    <Skeleton className="h-24 w-full rounded-lg" />
+                </div>
+            </AppShell>
+        );
+    }
+
+    if (isError || !data) {
+        return (
+            <AppShell headerTitle="주문 상세" headerVariant="detail" hasBack showBottomNav={false}>
+                <div className="py-12 flex flex-col items-center">
+                    <InlineError
+                        message="주문 정보를 불러올 수 없습니다."
+                        onRetry={() => refetch()}
+                    />
+                </div>
+            </AppShell>
+        );
+    }
+
+    const { order, items } = data;
+    const canCancel = order.status === 'PAID';
+
+    return (
+        <AppShell headerTitle="주문 상세" headerVariant="detail" hasBack showBottomNav={false}>
+            <div className="p-4 space-y-6 pb-24">
+                <section className="space-y-3">
+                    <h3 className="text-lg font-bold">주문 정보</h3>
+                    <Card className="border-border bg-card">
+                        <CardContent className="p-4 space-y-3">
+                            <div className="flex justify-between text-sm">
+                                <span className="text-muted-foreground">주문번호</span>
+                                <span className="font-mono text-xs">{order.orderNumber}</span>
+                            </div>
+                            <div className="flex justify-between text-sm">
+                                <span className="text-muted-foreground">주문상태</span>
+                                <span className="font-medium">{ORDER_STATUS_LABEL[order.status]}</span>
+                            </div>
+                            <div className="flex justify-between text-sm">
+                                <span className="text-muted-foreground">결제수단</span>
+                                <span>{PAYMENT_METHOD_LABELS[order.paymentMethod] || order.paymentMethod}</span>
+                            </div>
+                            <div className="flex justify-between text-sm">
+                                <span className="text-muted-foreground">주문일시</span>
+                                <span>{formatDateTime(order.createdAt)}</span>
+                            </div>
+                            {order.paidAt && (
+                                <div className="flex justify-between text-sm">
+                                    <span className="text-muted-foreground">결제일시</span>
+                                    <span>{formatDateTime(order.paidAt)}</span>
+                                </div>
+                            )}
+                            <Separator />
+                            <div className="flex justify-between font-bold text-lg">
+                                <span>결제금액</span>
+                                <span className="text-primary">{order.totalAmount.toLocaleString()}원</span>
+                            </div>
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <section className="space-y-3">
+                    <h3 className="text-lg font-bold">주문 아이템 ({items.length}건)</h3>
+                    <div className="divide-y divide-border">
+                        {items.map((item, index) => (
+                            <div key={item.id} className="py-3 flex items-center justify-between">
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-center gap-2">
+                                        <span className="text-xs text-muted-foreground">
+                                            #{index + 1}
+                                        </span>
+                                        <span className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                                            {ITEM_TYPE_LABEL[item.orderItemType]}
+                                        </span>
+                                        <span className="text-xs text-muted-foreground">
+                                            {ITEM_STATUS_LABEL[item.status]}
+                                        </span>
+                                    </div>
+                                    <p className="text-sm font-medium mt-1">
+                                        {item.amount.toLocaleString()}원
+                                    </p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="pt-4">
+                    <Button
+                        className="w-full h-12"
+                        variant="outline"
+                        disabled={!canCancel}
+                        onClick={() => {
+                            if (canCancel) {
+                                router.push(`/orders/cancel?orderId=${order.id}`);
+                            }
+                        }}
+                    >
+                        {canCancel ? '주문 취소' : '취소 불가'}
+                    </Button>
+                </div>
+
+                <Footer />
+            </div>
+        </AppShell>
+    );
+}

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -1,12 +1,62 @@
+'use client';
+
+import Link from 'next/link';
 import { AppShell } from '@/components/layout/AppShell';
 import { Footer } from '@/components/layout/Footer';
-import { ComingSoon } from '@/components/common/ComingSoon';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { InlineError } from '@/components/common/InlineError';
+import { useOrders } from '@/features/order/hooks/useOrders';
+import { OrderCard } from '@/features/order/components/OrderCard';
 
 export default function OrdersPage() {
+    const { data, isLoading, isError, refetch } = useOrders();
+
     return (
-        <AppShell headerTitle="주문배송" headerVariant="detail" hasBack showBottomNav={false}>
-            <ComingSoon title="주문배송" />
-            <Footer />
+        <AppShell headerTitle="주문내역" headerVariant="detail" hasBack showBottomNav={false}>
+            <div className="p-4">
+                {isLoading && (
+                    <div className="space-y-4">
+                        {[...Array(3)].map((_, i) => (
+                            <div key={i} className="py-4 border-b border-border space-y-2">
+                                <Skeleton className="h-3 w-32" />
+                                <Skeleton className="h-4 w-40" />
+                                <Skeleton className="h-3 w-24" />
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {isError && (
+                    <div className="py-12 flex flex-col items-center">
+                        <InlineError
+                            message="주문 내역을 불러올 수 없습니다."
+                            onRetry={() => refetch()}
+                        />
+                    </div>
+                )}
+
+                {data && data.items.length === 0 && (
+                    <div className="py-12 flex flex-col items-center gap-4">
+                        <p className="text-sm text-muted-foreground">
+                            주문 내역이 없습니다
+                        </p>
+                        <Button variant="outline" size="sm" asChild>
+                            <Link href="/">홈으로 가기</Link>
+                        </Button>
+                    </div>
+                )}
+
+                {data && data.items.length > 0 && (
+                    <div>
+                        {data.items.map((order) => (
+                            <OrderCard key={order.id} order={order} />
+                        ))}
+                    </div>
+                )}
+
+                <Footer />
+            </div>
         </AppShell>
     );
 }

--- a/src/features/order/components/OrderCard.tsx
+++ b/src/features/order/components/OrderCard.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link';
+import { ChevronRight } from 'lucide-react';
+import type { Order, OrderStatus } from '@/types/order';
+
+const STATUS_LABEL: Record<OrderStatus, string> = {
+    CREATED: '주문생성',
+    PAID: '결제완료',
+    PARTIAL_CONFIRMED: '부분확정',
+    CONFIRMED: '주문확정',
+    PARTIAL_CANCELING: '부분취소중',
+    CANCELING: '취소처리중',
+    PARTIAL_CANCELED: '부분취소',
+    CANCELED: '주문취소',
+};
+
+const STATUS_STYLE: Record<OrderStatus, string> = {
+    CREATED: 'bg-muted text-muted-foreground',
+    PAID: 'bg-foreground/10 text-foreground',
+    PARTIAL_CONFIRMED: 'bg-foreground/10 text-foreground',
+    CONFIRMED: 'bg-muted text-muted-foreground',
+    PARTIAL_CANCELING: 'bg-foreground/10 text-foreground',
+    CANCELING: 'bg-foreground/10 text-foreground',
+    PARTIAL_CANCELED: 'bg-muted text-muted-foreground',
+    CANCELED: 'bg-muted text-muted-foreground',
+};
+
+function formatDate(dateStr: string) {
+    return new Date(dateStr).toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    });
+}
+
+interface OrderCardProps {
+    order: Order;
+}
+
+export function OrderCard({ order }: OrderCardProps) {
+    return (
+        <Link
+            href={`/orders/${order.id}`}
+            className="flex items-center justify-between py-4 border-b border-border"
+        >
+            <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 mb-1">
+                    <span className="text-xs font-mono text-muted-foreground">
+                        {order.orderNumber}
+                    </span>
+                    <span className={`inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded ${STATUS_STYLE[order.status]}`}>
+                        {STATUS_LABEL[order.status]}
+                    </span>
+                </div>
+                <p className="text-sm font-medium">
+                    {order.quantity}건 · {order.totalAmount.toLocaleString()}원
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                    {formatDate(order.createdAt)}
+                </p>
+            </div>
+            <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0 ml-2" />
+        </Link>
+    );
+}

--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -30,6 +30,7 @@ interface BackendOrderSummary {
   status: string;
   paymentMethod: string;
   createdAt: string;
+  paidAt: string | null;
   confirmedAt: string | null;
   cancelledAt: string | null;
 }
@@ -95,6 +96,7 @@ function mapBackendOrder(backend: BackendOrderSummary): Order {
     status: backend.status as Order['status'],
     paymentMethod: backend.paymentMethod as PaymentMethod,
     createdAt: backend.createdAt,
+    paidAt: backend.paidAt,
     confirmedAt: backend.confirmedAt,
     cancelledAt: backend.cancelledAt,
   };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -719,4 +719,240 @@ export const handlers = [
     return new HttpResponse(null, { status: 204 });
   }),
 
+  // ============================================
+  // ORDERS
+  // ============================================
+  http.get('**/api/v2/orders', ({ request }) => {
+    const url = new URL(request.url);
+    const page = parseInt(url.searchParams.get('page') || '0');
+    const size = parseInt(url.searchParams.get('size') || '20');
+
+    const mockOrders = [
+      {
+        orderId: 1001,
+        orderNumber: 'ORD-20260223-001',
+        quantity: 2,
+        totalAmount: { amount: 50000 },
+        status: 'PAID',
+        paymentMethod: 'DEPOSIT',
+        createdAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+        paidAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000 + 60000).toISOString(),
+        confirmedAt: null,
+        cancelledAt: null,
+      },
+      {
+        orderId: 1002,
+        orderNumber: 'ORD-20260222-002',
+        quantity: 1,
+        totalAmount: { amount: 35000 },
+        status: 'CONFIRMED',
+        paymentMethod: 'KAKAO_PAY',
+        createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+        paidAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000 + 60000).toISOString(),
+        confirmedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+        cancelledAt: null,
+      },
+      {
+        orderId: 1003,
+        orderNumber: 'ORD-20260220-003',
+        quantity: 3,
+        totalAmount: { amount: 120000 },
+        status: 'CANCELED',
+        paymentMethod: 'CARD',
+        createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+        paidAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000 + 60000).toISOString(),
+        confirmedAt: null,
+        cancelledAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+      {
+        orderId: 1004,
+        orderNumber: 'ORD-20260218-004',
+        quantity: 1,
+        totalAmount: { amount: 25000 },
+        status: 'PARTIAL_CANCELED',
+        paymentMethod: 'DEPOSIT',
+        createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+        paidAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000 + 60000).toISOString(),
+        confirmedAt: null,
+        cancelledAt: null,
+      },
+    ];
+
+    const start = page * size;
+    const end = start + size;
+    const paginated = mockOrders.slice(start, end);
+
+    return HttpResponse.json({
+      orders: paginated,
+      page,
+      size,
+      totalElements: mockOrders.length,
+      totalPages: Math.ceil(mockOrders.length / size),
+      hasNext: end < mockOrders.length,
+      hasPrevious: page > 0,
+    });
+  }),
+
+  http.get('**/api/v2/orders/:orderId', ({ params }) => {
+    const { orderId } = params;
+
+    const orderMap: Record<string, object> = {
+      '1001': {
+        orderDetail: {
+          order: {
+            orderId: 1001,
+            orderNumber: 'ORD-20260223-001',
+            quantity: 2,
+            totalAmount: { amount: 50000 },
+            status: 'PAID',
+            paymentMethod: 'DEPOSIT',
+            createdAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+            paidAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000 + 60000).toISOString(),
+            confirmedAt: null,
+            cancelledAt: null,
+          },
+          items: [
+            {
+              orderItemId: 2001,
+              targetId: 100,
+              orderItemType: 'FUNDING_GIFT',
+              sellerId: 10,
+              receiverId: 20,
+              price: { amount: 30000 },
+              amount: { amount: 30000 },
+              status: 'PAID',
+              cancelledAt: null,
+            },
+            {
+              orderItemId: 2002,
+              targetId: 101,
+              orderItemType: 'NORMAL_GIFT',
+              sellerId: 10,
+              receiverId: 30,
+              price: { amount: 20000 },
+              amount: { amount: 20000 },
+              status: 'PAID',
+              cancelledAt: null,
+            },
+          ],
+        },
+      },
+      '1002': {
+        orderDetail: {
+          order: {
+            orderId: 1002,
+            orderNumber: 'ORD-20260222-002',
+            quantity: 1,
+            totalAmount: { amount: 35000 },
+            status: 'CONFIRMED',
+            paymentMethod: 'KAKAO_PAY',
+            createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+            paidAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000 + 60000).toISOString(),
+            confirmedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+            cancelledAt: null,
+          },
+          items: [
+            {
+              orderItemId: 2003,
+              targetId: 102,
+              orderItemType: 'FUNDING_GIFT',
+              sellerId: 10,
+              receiverId: 40,
+              price: { amount: 35000 },
+              amount: { amount: 35000 },
+              status: 'CONFIRMED',
+              cancelledAt: null,
+            },
+          ],
+        },
+      },
+      '1003': {
+        orderDetail: {
+          order: {
+            orderId: 1003,
+            orderNumber: 'ORD-20260220-003',
+            quantity: 3,
+            totalAmount: { amount: 120000 },
+            status: 'CANCELED',
+            paymentMethod: 'CARD',
+            createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+            paidAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000 + 60000).toISOString(),
+            confirmedAt: null,
+            cancelledAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+          },
+          items: [
+            {
+              orderItemId: 2004,
+              targetId: 103,
+              orderItemType: 'NORMAL_ORDER',
+              sellerId: 10,
+              receiverId: 50,
+              price: { amount: 40000 },
+              amount: { amount: 40000 },
+              status: 'CANCELED',
+              cancelledAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+            },
+            {
+              orderItemId: 2005,
+              targetId: 104,
+              orderItemType: 'FUNDING_GIFT',
+              sellerId: 10,
+              receiverId: 60,
+              price: { amount: 50000 },
+              amount: { amount: 50000 },
+              status: 'CANCELED',
+              cancelledAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+            },
+            {
+              orderItemId: 2006,
+              targetId: 105,
+              orderItemType: 'NORMAL_GIFT',
+              sellerId: 10,
+              receiverId: 70,
+              price: { amount: 30000 },
+              amount: { amount: 30000 },
+              status: 'CANCELED',
+              cancelledAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+            },
+          ],
+        },
+      },
+      '1004': {
+        orderDetail: {
+          order: {
+            orderId: 1004,
+            orderNumber: 'ORD-20260218-004',
+            quantity: 1,
+            totalAmount: { amount: 25000 },
+            status: 'PARTIAL_CANCELED',
+            paymentMethod: 'DEPOSIT',
+            createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+            paidAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000 + 60000).toISOString(),
+            confirmedAt: null,
+            cancelledAt: null,
+          },
+          items: [
+            {
+              orderItemId: 2007,
+              targetId: 106,
+              orderItemType: 'FUNDING_GIFT',
+              sellerId: 10,
+              receiverId: 80,
+              price: { amount: 25000 },
+              amount: { amount: 25000 },
+              status: 'CANCELED',
+              cancelledAt: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+            },
+          ],
+        },
+      },
+    };
+
+    const detail = orderMap[orderId as string];
+    if (!detail) {
+      return new HttpResponse(null, { status: 404 });
+    }
+    return HttpResponse.json(detail);
+  }),
+
 ];

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -28,19 +28,20 @@ export type OrderItemType = 'NORMAL_ORDER' | 'FUNDING_GIFT' | 'NORMAL_GIFT';
  * @see OrderStatus.java
  */
 export type OrderStatus =
-    | 'PAYMENT_PENDING'
+    | 'CREATED'
     | 'PAID'
+    | 'PARTIAL_CONFIRMED'
     | 'CONFIRMED'
-    | 'CANCELED'
-    | 'FAILED'
+    | 'PARTIAL_CANCELING'
+    | 'CANCELING'
     | 'PARTIAL_CANCELED'
-    | 'REFUNDED';
+    | 'CANCELED';
 
 /**
  * 주문 아이템 상태
  * @see OrderItemStatus.java
  */
-export type OrderItemStatus = 'CREATED' | 'PAID' | 'CANCELLED';
+export type OrderItemStatus = 'CREATED' | 'PAID' | 'CANCELING' | 'CANCELED' | 'CONFIRMED';
 
 /**
  * Order summary for list views
@@ -54,6 +55,7 @@ export interface Order {
     status: OrderStatus;
     paymentMethod: PaymentMethod;
     createdAt: string;
+    paidAt: string | null;
     confirmedAt: string | null;
     cancelledAt: string | null;
 }


### PR DESCRIPTION
## Summary
- 주문 목록/상세 페이지 UI 구현 (ComingSoon 스텁 → 실제 화면)
- OrderStatus/OrderItemStatus 타입을 백엔드 PR #273 실제 enum과 일치시킴
- MSW mock 핸들러 추가로 개발 환경 동작 지원

## 변경 내용
- `src/types/order.ts`: OrderStatus 8개 상태, OrderItemStatus 5개 상태로 수정, paidAt 추가
- `src/lib/api/orders.ts`: paidAt 매핑 추가
- `src/features/order/components/OrderCard.tsx`: 주문 카드 컴포넌트 (목록 아이템)
- `src/app/orders/page.tsx`: 주문 목록 (Loading/Error/Empty/List 상태)
- `src/app/orders/[id]/page.tsx`: 주문 상세 (주문 정보 카드 + 아이템 목록 + 취소 CTA)
- `src/mocks/handlers.ts`: 주문 목록/상세 MSW mock 데이터 4건

## 스코프 외
- 주문 취소 기능 (J47 별도 작업)
- 페이지네이션 UI

## Test plan
- [x] `npm run build` 성공 확인
- [x] MSW mock으로 주문 목록 페이지 렌더링 확인
- [x] 주문 카드 클릭 → 상세 페이지 이동 확인
- [x] Loading/Error/Empty 상태 렌더링 확인
- [x] 결제 완료 페이지 "주문 내역 보기" → `/orders` 이동 확인
