### PR TITLE
fix: ProductSort 타입 변경에 따른 빌드 에러 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ export default async function HomePage() {
     }),
     queryClient.prefetchQuery({
       queryKey: ['products', 'hot'],
-      queryFn: () => getProducts({ size: 4, sort: 'price_desc' }),
+      queryFn: () => getProducts({ size: 4, sort: 'PRICE_DESC' }),
     }),
   ]);
 


### PR DESCRIPTION
## Summary
- PR #7에서 ProductSort 타입이 대문자로 변경되었으나 `page.tsx`에서 소문자 `'price_desc'`를 사용하여 Vercel 빌드 실패
- `'PRICE_DESC'`로 수정

## Changes
- `src/app/page.tsx`: `sort: 'price_desc'` → `sort: 'PRICE_DESC'`